### PR TITLE
Upgrade to Sparc.Blossom 7.1, add localization, fix namespaces

### DIFF
--- a/Sparc.Blossom.Server/Pages/BlogList.razor
+++ b/Sparc.Blossom.Server/Pages/BlogList.razor
@@ -2,111 +2,43 @@
 @page "/blogs/{ChannelId}"
 
 <div class="blog-list">
-    <div class="background"><img src="images//Pattern_1.png" alt="" /></div>
-<h1 class="header">21 Days of Blossom</h1>
-<h2>Subtitle</h2>
-<div class="blog-post-list">
-    <BlogCard img="true" />
-        <BlogCard img="false" />
-        <BlogCard img="false" />
-        <BlogCard img="true" />
-
-    @*    <article class="blog-post">
-            <img src="https://via.placeholder.com/150" />
-            <h3>Title Here</h3>
-            <p>Introduce IRepository and the built-in InMemoryDatabase so you don't have to worry about picking a database at the beginning of developing your app</p>
-        </article>
-
-        <article class="blog-post no-img">
-            <h3>Channel.Name</h3>
-            <p>Here is text</p>
-        </article>
-
-        <article class="blog-post no-img">
-            <h3>Channel.Name</h3>
-            <p>Introduce IRepository and the built-in InMemoryDatabase so you don't have to worry about picking a database at the beginning of developing your app</p>
-        </article>
-
-        <article class="blog-post">
-            <img src="https://via.placeholder.com/150" />
-            <h3>Title Here</h3>
-            <p>Introduce IRepository and the built-in InMemoryDatabase so you don't have to worry about picking a database at the beginning of developing your app</p>
-        </article>
-
-        <article class="blog-post no-img">
-            <h3>Channel.Name</h3>
-            <p>Here is text</p>
-        </article>*@
-
-        @if (Channel != null)
+    <div class="background"><img src="images/Pattern_1.png" alt="" /></div>
+    <h1 class="header">21 Days of Blossom</h1>
+    <h2>Blog</h2>
+    <div class="blog-post-list">
+        @foreach (var post in Content)
         {
-            foreach (var item in Channel.Content)
-            {
-
-                if (img == true)
-                {
-                    <article class="blog-post">
-                        <img src="https://via.placeholder.com/150" />
-                        <h2>Title Here</h2>
-                        <p>Hello here is article text...</p>
-                    </article>
-                } else
-                {
-                    <article class="blog-post no-img">
-                        <h2 @onclick="() => NavigateToBlogEntry(ChannelId, item.Tag)">Title</h2>
-                        <p>@item.Text.Substring(0, item.Text.Length < 100 ? item.Text.Length : 100) ...</p>
-                    </article>
-                }
-            }
+            <div @onclick="@(e => GoTo(post))">
+                <BlogPost Post="post" />
+            </div>
         }
-
-
-</div>
+    </div>
 </div>
 
 @inject NavigationManager Navigation
 
 @code {
-    //public string Content = "";
-    IbisChannel? Channel;
-    //List<IbisContent>? blogContent;
     public bool img = false;
-    [Parameter] public string? ChannelId { get; set; } = "blog-testing";
-    List<string> DefaultChannels = new() { "law-of-100-blog" };
+    [Parameter] public string? ChannelId { get; set; } = null!;
+    List<string> DefaultChannels = new() { "new-blossom-blog" };
     List<IbisContent> Content = new();
-    //IbisContent? testContent;
 
     protected override async Task OnInitializedAsync()
     {
-
-
-        var channel = await Ibis.GetAllAsync("blog-testing", asHtml: false, take: 2);
-
-
         //if (ChannelId != null)
         //{
-        //    var channel = await Ibis.GetAllAsync(ChannelId, asHtml: true);
+        //    var channel = await Ibis.GetAllAsync(ChannelId, asHtml: true, take: 10);
         //    Content.AddRange(channel!.Content);
         //}
         //else
         //{
-        //    foreach (var channel in DefaultChannels)
-        //    {
-        //        var channelContent = await Ibis.GetAllAsync(channel, asHtml: true);
-        //        Content.AddRange(channelContent!.Content);
-        //    }
-        //    Content = Content.OrderByDescending(x => x.Timestamp).ToList();
-        //}
-
-        //testContent = await Ibis.GetAsync("", "test");
-
-        //Content = Ibis.Get("test");
+        foreach (var channel in DefaultChannels)
+        {
+            var channelContent = await Ibis.GetAllAsync(channel, asHtml: true, take: 10);
+            Content.AddRange(channelContent!.Content);
+        }
+        Content = Content.OrderByDescending(x => x.Timestamp).ToList();
     }
 
-    private void NavigateToBlogEntry(string name, string tag)
-    {
-        Navigation.NavigateTo("blog/" + name + "/" + tag);
-    }
-
-    //public void GoTo(IbisContent content) => Nav.NavigateTo($"/blogs/{content.RoomSlug}/{content.Tag}");
+    public void GoTo(IbisContent content) => Nav.NavigateTo($"/blogs/{content.RoomSlug}/{content.Tag}");
 }

--- a/Sparc.Blossom.Server/Pages/BlogPost.razor
+++ b/Sparc.Blossom.Server/Pages/BlogPost.razor
@@ -1,4 +1,4 @@
-﻿@*<article class="blog-post ibis-ignore">
+﻿<article class="blog-post ibis-ignore">
     <header>
         @if (Post["title"] != null)
         {
@@ -40,4 +40,3 @@
 @code {
     [Parameter] public IbisContent Post { get; set; } = null!;
 }
-*@

--- a/Sparc.Blossom.Server/Pages/_Host.cshtml
+++ b/Sparc.Blossom.Server/Pages/_Host.cshtml
@@ -22,7 +22,7 @@
 </head>
 <body>
     <app>
-        <component type="typeof(Sparc.Blossom.Server.App)" render-mode="ServerPrerendered" />
+        <component type="typeof(Sparc.Blossom.App)" render-mode="ServerPrerendered" />
     </app>
 
     <script src="_framework/blazor.server.js"></script>

--- a/Sparc.Blossom.Server/Program.cs
+++ b/Sparc.Blossom.Server/Program.cs
@@ -1,29 +1,19 @@
+using Sparc.Blossom;
 using Sparc.Ibis;
-using Sparc.Kernel;
-using System.Globalization;
-
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 
-builder.AddSparcKernel();
-builder.Services
-    .AddIbis();
+builder.AddBlossom();
+builder.Services.AddIbis();
+builder.Services.AddLocalization();
 
 var app = builder.Build();
 
-var supportedCultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
-    .Select(x => x.Name)
-    .ToArray();
-
 app.UseStaticFiles();
-
-app.UseRequestLocalization(options => options
-    .AddSupportedCultures(supportedCultures)
-    .AddSupportedUICultures(supportedCultures));
-
+app.UseAllCultures();
 app.MapBlazorHub();
 app.MapFallbackToPage("/_Host");
 

--- a/Sparc.Blossom.Server/Sparc.Blossom.csproj
+++ b/Sparc.Blossom.Server/Sparc.Blossom.csproj
@@ -33,8 +33,8 @@
   <ItemGroup>
     <PackageReference Include="BuildWebCompiler2022" Version="1.14.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0" />
-    <PackageReference Include="Sparc.Ibis" Version="7.0.13" />
-    <PackageReference Include="Sparc.Kernel" Version="7.0.31" />
+    <PackageReference Include="Sparc.Blossom.Server" Version="7.1.0-pre.7" />
+    <PackageReference Include="Sparc.Ibis" Version="7.1.0-pre.2" />
   </ItemGroup>
 
 </Project>

--- a/Sparc.Blossom.Server/_Imports.razor
+++ b/Sparc.Blossom.Server/_Imports.razor
@@ -11,9 +11,9 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 
-@using Sparc.Core
-@using Sparc.Blossom.Server.Pages
-@using Sparc.Blossom.Server.Shared
+@using Sparc.Blossom
+@using Sparc.Blossom.Pages
+@using Sparc.Blossom.Shared
 @using Sparc.Ibis
 
 @inject IJSRuntime JSRuntime

--- a/Sparc.Blossom.Server/swagger.json
+++ b/Sparc.Blossom.Server/swagger.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "Sparc.Blossom.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+    "title": "Sparc.Blossom, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
     "version": "v1"
   },
   "paths": { },

--- a/Sparc.Blossom.sln
+++ b/Sparc.Blossom.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33027.239
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sparc.Blossom.Server", "Sparc.Blossom.Server\Sparc.Blossom.Server.csproj", "{FBFFA6F0-F4D7-4EA2-9DF5-8DF4A84AFBDC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sparc.Blossom", "Sparc.Blossom.Server\Sparc.Blossom.csproj", "{FBFFA6F0-F4D7-4EA2-9DF5-8DF4A84AFBDC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{04D15CC4-3E04-4212-9AA3-5883C0B3888E}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
- Upgraded to Sparc.Blossom 7.1 and Sparc.Ibis 7.1-pre.2
- Changed the name of the project (csproj) after upgrading, because apparently a project called Sparc.Blossom.Server can't reference a package called Sparc.Blossom.Server :-p 
- Added `services.AddLocalization()` per https://learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?view=aspnetcore-7.0&pivots=server to ensure that the Blazor Server localization middleware gets called. I can't add this directly to a helper method in Sparc.Ibis because Sparc.Ibis has to run with WebAsssembly as well (meaning it's a Razor Class Library), and `services.AddLocalization()` is only a Blazor Server (i.e. full ASP.NET Core) method.
- Added `app.UseAllCultures()` new helper method from Sparc.Blossom.Server. I added this last week as a workaround for the same problem above (can't do it in Sparc.Ibis directly). It's uglier than I'd like, not sure the right solution yet, but for now this should work!